### PR TITLE
[feat] 공통 응답 구조 도입 및 전역 예외 처리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ dependencies {
     // 서버는 MVC 그대로, WebClient만 사용하기 위해 webflux 스타터 추가
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    // === 편의성 ===
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
     // === 테스트 ===
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/manil/manil/global/domain/BaseEntity.java
+++ b/src/main/java/com/manil/manil/global/domain/BaseEntity.java
@@ -1,0 +1,29 @@
+package com.manil.manil.global.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.OffsetDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false,
+            columnDefinition = "timestamptz")
+    private OffsetDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "timestamptz")
+    private OffsetDateTime updatedAt;
+}

--- a/src/main/java/com/manil/manil/global/exception/BusinessException.java
+++ b/src/main/java/com/manil/manil/global/exception/BusinessException.java
@@ -1,0 +1,27 @@
+package com.manil.manil.global.exception;
+
+import com.manil.manil.global.exception.error.BaseError;
+import org.springframework.http.HttpStatus;
+
+public class BusinessException extends RuntimeException {
+    private final BaseError baseError;
+
+    public BusinessException(BaseError baseError) {
+        super(baseError.getMessage());
+        this.baseError = baseError;
+    }
+
+    public BusinessException(BaseError baseError, Throwable cause) {
+        super(baseError.getMessage(), cause);
+        this.baseError = baseError;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return baseError.getHttpStatus();
+    }
+
+    @Override
+    public String getMessage() {
+        return baseError.getMessage();
+    }
+}

--- a/src/main/java/com/manil/manil/global/exception/ErrorResponse.java
+++ b/src/main/java/com/manil/manil/global/exception/ErrorResponse.java
@@ -1,0 +1,39 @@
+package com.manil.manil.global.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ErrorResponse(
+        int status,
+        String error,
+        String message,
+        LocalDateTime timestamp,
+        String path
+) {
+
+    @Builder
+    public ErrorResponse {}
+
+    public static ErrorResponse of(HttpStatus httpStatus, String message) {
+        return ErrorResponse.builder()
+                .status(httpStatus.value())
+                .error(httpStatus.getReasonPhrase())
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    public static ErrorResponse of(HttpStatus httpStatus, String message, String path) {
+        return ErrorResponse.builder()
+                .status(httpStatus.value())
+                .error(httpStatus.getReasonPhrase())
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .path(path)
+                .build();
+    }
+}

--- a/src/main/java/com/manil/manil/global/exception/ExceptionHandlerAdvice.java
+++ b/src/main/java/com/manil/manil/global/exception/ExceptionHandlerAdvice.java
@@ -1,0 +1,123 @@
+package com.manil.manil.global.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionHandlerAdvice {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> businessExceptionHandler(
+            BusinessException exception,
+            HttpServletRequest request
+    ) {
+        // Text Blocks 사용 (Java 15+)
+        var logMessage = """
+            Business Error Details:
+            - URI: {}
+            - Error: {}
+            - Status: {}
+            """;
+
+        // Enhanced switch expression (Java 14+) - 올바른 사용법
+        switch (exception.getHttpStatus().series()) {
+            case CLIENT_ERROR -> log.warn(logMessage,
+                    request.getRequestURI(),
+                    exception.getMessage(),
+                    exception.getHttpStatus());
+            case SERVER_ERROR -> log.error(logMessage,
+                    request.getRequestURI(),
+                    exception.getMessage(),
+                    exception.getHttpStatus(),
+                    exception);
+            default -> log.info(logMessage,
+                    request.getRequestURI(),
+                    exception.getMessage(),
+                    exception.getHttpStatus());
+        }
+
+        var errorResponse = ErrorResponse.of(
+                exception.getHttpStatus(),
+                exception.getMessage(),
+                request.getRequestURI()
+        );
+
+        return ResponseEntity.status(exception.getHttpStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> validationExceptionHandler(
+            MethodArgumentNotValidException exception,
+            HttpServletRequest request
+    ) {
+        log.warn("Validation Error at {}: ", request.getRequestURI(), exception);
+
+        var errorMessage = exception.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(FieldError::getDefaultMessage)
+                .filter(message -> message != null && !message.isBlank())
+                .collect(Collectors.joining(", "));
+
+        var errorResponse = ErrorResponse.of(
+                HttpStatus.BAD_REQUEST,
+                errorMessage.isBlank() ? "잘못된 요청입니다." : errorMessage,
+                request.getRequestURI()
+        );
+
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> illegalArgumentExceptionHandler(
+            IllegalArgumentException exception,
+            HttpServletRequest request
+    ) {
+        log.warn("Illegal Argument at {}: {}", request.getRequestURI(), exception.getMessage());
+
+        var errorResponse = ErrorResponse.of(
+                HttpStatus.BAD_REQUEST,
+                exception.getMessage(),
+                request.getRequestURI()
+        );
+
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> generalExceptionHandler(
+            Exception exception,
+            HttpServletRequest request
+    ) {
+        // Java 17에서 사용 가능한 instanceof pattern matching
+        String errorMessage;
+        if (exception instanceof NullPointerException) {
+            errorMessage = "필수 값이 누락되었습니다.";
+        } else if (exception instanceof IllegalStateException) {
+            errorMessage = "잘못된 상태입니다.";
+        } else if (exception instanceof RuntimeException) {
+            errorMessage = "처리 중 오류가 발생했습니다.";
+        } else {
+            errorMessage = "서버 내부 오류가 발생했습니다.";
+        }
+
+        log.error("Unexpected Error at {}: ", request.getRequestURI(), exception);
+
+        var errorResponse = ErrorResponse.of(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                errorMessage,
+                request.getRequestURI()
+        );
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+}

--- a/src/main/java/com/manil/manil/global/exception/error/BaseError.java
+++ b/src/main/java/com/manil/manil/global/exception/error/BaseError.java
@@ -1,0 +1,8 @@
+package com.manil.manil.global.exception.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseError {
+    HttpStatus getHttpStatus();
+    String getMessage();
+}

--- a/src/main/java/com/manil/manil/global/payload/ResponseDto.java
+++ b/src/main/java/com/manil/manil/global/payload/ResponseDto.java
@@ -1,0 +1,31 @@
+package com.manil.manil.global.payload;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ResponseDto<T> {
+
+    private final LocalDateTime timeStamp;
+    private final String message;
+    private final T data;
+
+    protected ResponseDto(LocalDateTime timeStamp, String message, T data) {
+        this.timeStamp = timeStamp;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ResponseDto<T> of(String message) {
+        return new ResponseDto<>(LocalDateTime.now(), message, null);
+    }
+
+    public static <T> ResponseDto<T> of(T body) {
+        return new ResponseDto<>(LocalDateTime.now(), null, body);
+    }
+
+    public static <T> ResponseDto<T> of(T body, String message) {
+        return new ResponseDto<>(LocalDateTime.now(), message, body);
+    }
+}


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #6 
---
### 📌 요약
- ApiResponse 도입
- BaseEntity 추가
- GlobalExceptionHandler 추가

### ✅ 작업 내용	\
- ApiResponse 도입
- GlobalExceptionHandler 추가
- 도메인용 ApiException(ErrorCode) 처리
- 일반 Exception에 대한 안전한 500 응답
- HTTP Status 매핑 일원화
- (BAD_REQUEST/NOT_FOUND/RATE_LIMIT/TIMEOUT 등)
- BaseEntity 개선 가이드 반영
- id/createdAt/updatedAt 불변 속성화, timestamptz 권장

### 📚 참고 자료, 할 말
-마지막 까지 화이팅 해요
